### PR TITLE
Provide a non-watch way of running tests locally

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -36,12 +36,12 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom --coverage",
-    "test:watch": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom",
+    "test:once": "CI=true yarn test -- --coverage",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint 'client/**/*.js' --max-warnings 0",
     "lint:sass": "sass-lint -v --max-warnings 0",
-    "validate": "npm-run-all --parallel lint test"
+    "validate": "npm-run-all --parallel lint test:once"
   }
 }

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -36,7 +36,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --coverage",
+    "test:watch": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint 'client/**/*.js' --max-warnings 0",


### PR DESCRIPTION
When running `yarn validate` locally, we want the tests to run once and stop, but `yarn test` runs in watch mode.

This PR adds a `test:once` script that:

a) sets the `CI` environment variable, which is the recommended way of disabling watch mode.
b) sets the `—coverage` flag so that we can see our code coverage information when running the tests.

Fixes #24 