### PR TITLE
Install yarn.lock in target project

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -34,6 +34,11 @@ module.exports = class ReactZeal extends Generator {
       this.destinationPath('.sass-lint.yml')
     )
 
+    this.fs.copy(
+      this.templatePath('yarn.lock'),
+      this.destinationPath('yarn.lock')
+    )
+
     this._mergeGitIgnore()
   }
 


### PR DESCRIPTION
We added a `yarn.lock` file a while back, but we weren’t installing it into the generated project.

As a result, running `yarn install` in the generated project can end up with newer dependencies than what we’ve tested with, which is not what we want.

This PR copies the yarn.lock file into place in the generated project.

NOTE: This could cause a conflict if we were to run the generator in a project that is using a JS back-end, as that project might already have a `yarn.lock` file.   This is already an issue for `package.json`, so I think we can safely choose to cross that bridge when we come to it.