### PR TITLE
Rename test scripts to match our conventions

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "CI=true yarn test:watch -- --coverage",
+    "test": "CI=true react-scripts test --env=jsdom --coverage",
     "test:watch": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:*",

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -38,12 +38,12 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "test:once": "CI=true yarn test -- --coverage",
+    "test": "CI=true yarn test:watch -- --coverage",
+    "test:watch": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint 'client/**/*.js' --max-warnings 0",
     "lint:sass": "sass-lint -v --max-warnings 0",
-    "validate": "npm-run-all --parallel lint test:once"
+    "validate": "npm-run-all --parallel lint test"
   }
 }


### PR DESCRIPTION
Most of our JS packages have `test` and `test:watch` scripts, where `test` runs the tests once and `test:watch` continuously runs them as files change.  However, create-react-app defines only a `test` target that normally watches, but switches into “run once” mode if the `CI` env var is set to `true`.  We originally wanted to keep our generator consistent with CRA, so we had a `test` target that does watch mode, and added a separate `test:once` target for doing a one-time run.

This PR changes the scripts back to our normal convention of `test` and `test:watch`.

It’s kinda weird to have the `test` task forward on to the `test:watch` task, but I didn’t want to repeat the `react-scripts` call in two places.