### PR TITLE
Run yarn install after generating

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -46,6 +46,14 @@ module.exports = class ReactZeal extends Generator {
     this._mergeGitIgnore()
   }
 
+  install() {
+    this.installDependencies({
+      yarn: true,
+      npm: false,
+      bower: false
+    })
+  }
+
   _mergeGitIgnore() {
     const template = this.fs.read(this.templatePath('gitignore'))
     const existing = this.fs.read(this.destinationPath('.gitignore'), {


### PR DESCRIPTION
Rather than forcing the user to remember to run `yarn` before trying to use the generated app, the generator now runs it for us.