### PR TITLE
Fall back to `npm install` if yarn isn't available

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ mkdir myApp && cd myApp
 # Run the generator
 yo react-zeal
 
-# Install
-npm install
-
 # start your app on http://localhost:3000
 npm start
 ```

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,5 @@
 const Generator = require('yeoman-generator')
+const commandExists = require('command-exists')
 const humps = require('humps')
 
 module.exports = class ReactZeal extends Generator {
@@ -47,9 +48,10 @@ module.exports = class ReactZeal extends Generator {
   }
 
   install() {
+    const isYarnAvailable = commandExists.sync('yarnpkg')
     this.installDependencies({
-      yarn: true,
-      npm: false,
+      yarn: isYarnAvailable,
+      npm: !isYarnAvailable,
       bower: false
     })
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "command-exists": "^1.2.2",
     "humps": "^2.0.0",
     "yeoman-generator": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,6 +530,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.2.tgz#12819c64faf95446ec0ae07fe6cafb6eb3708b22"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
Based on an idea from https://github.com/imperodesign/generator-impero/blob/development/generators/app/index.js#L329, use the `command-exists` package to check if yarn is available on the target system.  If so, install dependencies with yarn; otherwise, install them with npm.

There is a chance that yeoman's generator [will eventually support this automatically](https://github.com/yeoman/generator/issues/991).  If that happens, we can simplify what we're doing here.

Note that I check for the longer `yarnpkg` name, as there is another tool named `yarn` that may be installed on the target system, so `yarnpkg` is safer in this context.

I also removed the `npm install` instructions from the README, since that step is now performed automatically.