### PR TITLE
Add format script

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -31,15 +31,15 @@
     "zeal-redux-utils": "^1.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "CI=true react-scripts test --env=jsdom --coverage",
-    "test:watch": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "react-scripts lint --max-warnings 0",
     "lint:sass": "sass-lint -v --max-warnings 0",
     "precommit": "lint-staged",
+    "start": "react-scripts start",
+    "test": "CI=true react-scripts test --env=jsdom --coverage",
+    "test:watch": "react-scripts test --env=jsdom",
     "validate": "npm-run-all --parallel lint test"
   },
   "lint-staged": {

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "react-scripts build",
     "eject": "react-scripts eject",
+    "format": "prettier --write 'client/**/*.js'",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "react-scripts lint --max-warnings 0",
     "lint:sass": "sass-lint -v --max-warnings 0",


### PR DESCRIPTION
With this change, people can do `yarn format` to run prettier against the codebase.  This makes it easier for folks that don't have the editor integration set up.

I also re-ordered the scripts alphabetically to make it easier to find scripts.