### PR TITLE
Generate a README with common documentation

### DIFF
--- a/app/templates/client/README.md
+++ b/app/templates/client/README.md
@@ -1,0 +1,40 @@
+This React project was created with [Coding Zeal's React Generator](https://github.com/CodingZeal/generator-react-zeal). See the documentation at that site for in depth documentation with regard to creation of React Components and theming, but here's some documentation to get you started.
+
+Environment Variables
+==========================
+
+This application uses [dotenv](https://www.npmjs.com/package/dotenv) and reads environmental variables from `.env`, `.env.development`.
+
+If you are using this template as part of a server side application, like Rails or Phoenix, it's important you do **NOT** use the tools these frameworks provide to read environmental variables from these files. (At best, this may start two servers on the same `PORT`!!!!!)
+
+Application server and port
+===========================
+
+You can run your React application using `yarn start` (or `npm start`) and by default the React frontend is served from `localhost:3000`. 
+
+
+Use in the context of a larger framework
+=========================
+
+Overriding the PORT the React app is served from
+-------------------------
+
+If you are in the context of a larger framework, there are two environmental variables to modify to start on the desired port:
+
+  1. `APP_PORT`: updates the port number displayed to the user as part of the startup routine
+  2. `PORT`: updates the actual port the server listens to. (it does not update the startup documentation!)
+
+
+Overriding default graphql endpoint
+-------------------------
+
+By default, React Apollo sends GraphQL requests to `/graphql`, aka *expects this endpoint to be served off the same host and port as the React application itself*.
+
+When using this application in the context of a larger framework, this may not be true.
+
+To set the GraphQL host and port to something different, modify `client/base/apolloClient.js` as appropriate to the version of Apollo Client currently used (1.x uses a `networkInterface` key, 2.x uses `link`, per the [Apollo Client Upgrade Guide](https://github.com/apollographql/apollo-client/blob/master/Upgrade.md))
+
+App Specific Instructions
+=========================
+
+(Delete me and add your own!!!)


### PR DESCRIPTION
I was recently given a project that contained a front end generated by the React Zeal generator.

This project (which contained the Zeal application embedded in a Rails app) posted many difficulties in getting the application up, and obviously your generator contains some nicities that I would have had to find purely by reverse engineering the application. (ie theming).

(I'm sure you can figure out what those difficulties were by looking at the readme and seeing where that leans ;) )

By  pure luck I managed to find that this was automatically generated code, not artisanally, handcrafted code, and that this was the source code for that generator!

My patch adds a `README.md` to the client folder, such that every new project generated will have some idea about origin of the code, getting-it-up-on-my-machine concerns, and other potentially common problems that may technically be the domain of downstream projects, but are worth documenting here as a one stop shop).

Of course, as generated code, the user is free to delete the README or repurpose it, like so many README files in so many Rails generated projects.

Also, say hi to Frank for me. ;-)
