### PR TITLE
Updates react-css-themr

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -18,7 +18,7 @@
     "ramda": "^0.23.0",
     "react": "^15.5.4",
     "react-apollo": "^1.2.0",
-    "react-css-themr": "^2.0.0",
+    "react-css-themr": "^2.1.0",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.1.1",

--- a/app/templates/yarn.lock
+++ b/app/templates/yarn.lock
@@ -5747,10 +5747,11 @@ react-apollo@^1.2.0:
   optionalDependencies:
     react-dom "0.14.x || 15.* || ^15.0.0 || ^16.0.0-alpha"
 
-react-css-themr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-css-themr/-/react-css-themr-2.0.0.tgz#c4f93b9284009d9b4565121f09eb6b2bf402c3ef"
+react-css-themr@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-css-themr/-/react-css-themr-2.1.2.tgz#e017514e471c232f43a754a55b49d81faf5dafb8"
   dependencies:
+    hoist-non-react-statics "^1.2.0"
     invariant "^2.2.1"
 
 react-dev-utils@^3.0.0:


### PR DESCRIPTION
This removes the "Accessing PropTypes via the main React package is
deprecated" warning in the console.